### PR TITLE
downgrade node to 20.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:20.2.0
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
Latest node version 20.3.0 causes "text file busy" when building, downgrading to 20.2.0 should fix the issue. 