### PR TITLE
search bar fix

### DIFF
--- a/components/CardList/_cardList.scss
+++ b/components/CardList/_cardList.scss
@@ -111,16 +111,6 @@
 }
 
 .app-cards__link--publisher {
-  // Make the entire list item area clickable
-  &:after {
-    bottom: 0;
-    content: "";
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-  }
-
   &:hover {
     &:before {
       border-color: $govuk-link-hover-colour;

--- a/components/Search/_search.scss
+++ b/components/Search/_search.scss
@@ -33,6 +33,10 @@ $large-input-size: 50px;
   left: $icon-position;
 }
 
+.govuk-input__wrapper {
+  display: table;
+}
+
 .govuk-search__item {
   position: relative;
   display: table-cell;

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -6,9 +6,9 @@ export default function Search({}: {}) {
           Search data catalogue
         </label>
       </h1>
-      <div className="govuk-input__wrapper">
+      <div className="govuk-input__wrapper govuk-!-width-two-thirds">
         <input
-          className="govuk-input govuk-!-width-two-thirds govuk-search__item govuk-search__input js-class-toggle"
+          className="govuk-input govuk-search__item govuk-search__input js-class-toggle"
           id="weight"
           name="weight"
           type="search"


### PR DESCRIPTION
**header plus half way down page unclickable**
This was an issue with the 'publisher' sections clickable area being absolute and being moved tot the top of the page, making anything you clicked just link back to the homepage as that's where the publishers currently link to.

**Search bar was over extending**
**previous**
![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/b3bf25b2-97ab-4a13-b2d6-be51cb930306)

**current**
![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/ec5092e2-b105-4f20-a8ea-1e0e2277d406)
