### PR TITLE
banner border colours

### DIFF
--- a/components/Header/_header.scss
+++ b/components/Header/_header.scss
@@ -1,13 +1,35 @@
-.govuk-header {
-  border-bottom: revert !important;
+.govuk-header,
+.govuk-header__container {
+  border-bottom-width: 10px;
+  border-bottom-style: solid;
 }
 
 .govuk-header__container {
-  margin-bottom: revert !important;
-  border-bottom: revert !important;
-  padding-bottom: 10px;
+  margin-bottom: -10px;
 }
 
-.govuk-header__logo {
-  margin-bottom: revert !important;
+// Main coloured borders:
+.govuk-header.root-header {
+  border-bottom-color: govuk-colour("blue");
+}
+
+.govuk-header.non-root-header {
+  border-bottom-color: #ffffff;
+}
+
+.govuk-header.non-root-alt-header {
+  border-bottom-color: govuk-colour("dark-grey");
+}
+
+// Background blended borders:
+.govuk-header__container.root-header {
+  border-bottom-color: govuk-colour("yellow");
+}
+
+.govuk-header__container.non-root-header {
+  border-bottom-color: govuk-colour("blue");
+}
+
+.govuk-header__container.non-root-alt-header {
+  border-bottom-color: govuk-colour("blue");
 }

--- a/components/Header/_header.scss
+++ b/components/Header/_header.scss
@@ -9,27 +9,27 @@
 }
 
 // Main coloured borders:
-.govuk-header.root-header {
+.govuk-header--yellow-border {
   border-bottom-color: govuk-colour("blue");
 }
 
-.govuk-header.non-root-header {
+.govuk-header--blue-border {
   border-bottom-color: #ffffff;
 }
 
-.govuk-header.non-root-alt-header {
+.govuk-header--blue-alt-border {
   border-bottom-color: govuk-colour("dark-grey");
 }
 
 // Background blended borders:
-.govuk-header__container.root-header {
+.govuk-header__container--yellow-border {
   border-bottom-color: govuk-colour("yellow");
 }
 
-.govuk-header__container.non-root-header {
+.govuk-header__container--blue-border {
   border-bottom-color: govuk-colour("blue");
 }
 
-.govuk-header__container.non-root-alt-header {
+.govuk-header__container--blue-alt-border {
   border-bottom-color: govuk-colour("blue");
 }

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,20 +1,23 @@
 export default function Header({
   href,
   serviceName,
-  className = "root-header",
+  className = "yellow-border",
 }: {
   href?: string;
   serviceName?: string;
   className?: string;
 }) {
+  const headerClass = "govuk-header--" + className;
+  const containerClass = "govuk-header__container--" + className;
+
   return (
     <header
-      className={`govuk-header ${className}`}
+      className={`govuk-header ${headerClass}`}
       role="banner"
       data-module="govuk-header"
     >
       <div
-        className={`app-width-container govuk-header__container ${className}`}
+        className={`app-width-container govuk-header__container ${containerClass}`}
       >
         <div className="govuk-header__logo">
           <a

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,14 +1,14 @@
 export default function Header({
   href,
   serviceName,
-  className = "yellow-border",
+  borderColour = "yellow-border",
 }: {
   href?: string;
   serviceName?: string;
-  className?: string;
+  borderColour?: "yellow-border" | "blue-border" | "blue-alt-border";
 }) {
-  const headerClass = "govuk-header--" + className;
-  const containerClass = "govuk-header__container--" + className;
+  const headerClass = "govuk-header--" + borderColour;
+  const containerClass = "govuk-header__container--" + borderColour;
 
   return (
     <header

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,13 +1,21 @@
 export default function Header({
   href,
   serviceName,
+  className = "root-header",
 }: {
   href?: string;
   serviceName?: string;
+  className?: string;
 }) {
   return (
-    <header className="govuk-header" role="banner" data-module="govuk-header">
-      <div className="govuk-header__container app-width-container">
+    <header
+      className={`govuk-header ${className}`}
+      role="banner"
+      data-module="govuk-header"
+    >
+      <div
+        className={`app-width-container govuk-header__container ${className}`}
+      >
         <div className="govuk-header__logo">
           <a
             href={href || "/"}

--- a/components/PhaseBanner/_phaseBanner.scss
+++ b/components/PhaseBanner/_phaseBanner.scss
@@ -5,3 +5,7 @@
 .govuk-phase-banner__text--inverse {
   color: govuk-colour("white");
 }
+
+.govuk-phase-banner.alternative {
+  background: govuk-colour("dark-grey");
+}

--- a/components/PhaseBanner/_phaseBanner.scss
+++ b/components/PhaseBanner/_phaseBanner.scss
@@ -6,6 +6,6 @@
   color: govuk-colour("white");
 }
 
-.govuk-phase-banner.alternative {
+.govuk-phase-banner--alternative {
   background: govuk-colour("dark-grey");
 }


### PR DESCRIPTION
a `className` prop can now be passed to the header to change the bottom border colours.
a  `className` prop can now be passed to the phase banner to change it to the alternative grey.
**root header** used for homepage (css `root-header`)
![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/00e668ad-5611-4539-a047-ca302688a61e)

**non-root header** used for most other pages (css `non-root-header`)
![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/44481a19-ed32-4ef6-8446-c90f00bdb41e)

**non-root alternative header** used for topic page (css `non-root-alt-header`)
![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/74712cc3-71a9-440d-8b78-357fa4d6f75d)

**alternative phase banner** used for topic page (css `alternatife`
![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/a160bc78-8063-4e12-9e7d-7890ab76f45d)
