### PR TITLE
alternative hero header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,9 +3,7 @@ import CardList from "@/components/CardList";
 import {
   Hero,
   HeroActionButton,
-  HeroBreadcrumbs,
   HeroMainContent,
-  HeroMainContentCaption,
   HeroMainContentDescription,
   HeroMainContentTitle,
   HeroPhaseBanner,
@@ -137,38 +135,6 @@ export default async function Home() {
         </HeroMainContent>
         <HeroActionButton href="/catalogue" text="View data catalogue" />
       </Hero>
-      <div style={{ paddingBottom: 200 }}></div>
-      <Hero className="alternative">
-        <HeroPhaseBanner
-          href="#"
-          tag={{ children: "alpha", className: "alternative" }}
-        />
-        <HeroBreadcrumbs />
-        <HeroMainContent>
-          <HeroMainContentCaption caption="Topic" />
-          <HeroMainContentTitle title="Agriculture, energy and environment" />
-          <HeroMainContentDescription description="Food and farming, the natural environment, animal and plant health, flooding and water, fisheries, and environmental quality." />
-        </HeroMainContent>
-      </Hero>
-      {/* <Hero
-        title="Find government statistics and data"
-        description="Browse statistical summaries and download associated data to help you understand and analyse our range of statistics."
-        startButton={{ href: "/catalogue", text: "View data catalogue" }}
-        phaseBanner={{
-          href: "#",
-          tag: { children: "alpha" },
-        }}
-      /> */}
-      {/* <Hero
-        title="Agriculture, energy and environment"
-        caption="Topic"
-        description="Food and farming, the natural environment, animal and plant health, flooding and water, fisheries, and environmental quality."
-        className="alternative"
-        phaseBanner={{
-          href: "#",
-          tag: { children: "alpha", className: "alternative" },
-        }}
-      /> */}
       <SubHero>
         <Search />
       </SubHero>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,8 @@ import {
   HeroMainContentDescription,
   HeroMainContentTitle,
   HeroPhaseBanner,
+  HeroPhaseBannerTag,
+  HeroPhaseBannerDescription,
 } from "@/components/Hero";
 import SubHero from "@/components/Hero/SubHero";
 import Search from "@/components/Search";
@@ -128,12 +130,28 @@ export default async function Home() {
   return (
     <>
       <Hero>
-        <HeroPhaseBanner href="#" tag={{ children: "alpha" }} />
+        <HeroPhaseBanner>
+          <HeroPhaseBannerTag>Alpha</HeroPhaseBannerTag>
+          <HeroPhaseBannerDescription>
+            This is a new service - your{" "}
+            <a className="govuk-link govuk-link--inverse" href="/">
+              feedback
+            </a>{" "}
+            will help us to improve it.
+          </HeroPhaseBannerDescription>
+        </HeroPhaseBanner>
         <HeroMainContent>
-          <HeroMainContentTitle title="Find government statistics and data" />
-          <HeroMainContentDescription description="Browse statistical summaries and download associated data to help you understand and analyse our range of statistics." />
+          <HeroMainContentTitle>
+            Find government statistics and data
+          </HeroMainContentTitle>
+          <HeroMainContentDescription>
+            Browse statistical summaries and download associated data to help
+            you understand and analyse our range of statistics.
+          </HeroMainContentDescription>
         </HeroMainContent>
-        <HeroActionButton href="/catalogue" text="View data catalogue" />
+        <HeroActionButton href="/catalogue">
+          View data catalogue
+        </HeroActionButton>
       </Hero>
       <SubHero>
         <Search />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,15 @@
 import BigNumber from "@/components/BigNumber";
 import CardList from "@/components/CardList";
-import Hero from "@/components/Hero";
+import {
+  Hero,
+  HeroActionButton,
+  HeroBreadcrumbs,
+  HeroMainContent,
+  HeroMainContentCaption,
+  HeroMainContentDescription,
+  HeroMainContentTitle,
+  HeroPhaseBanner,
+} from "@/components/Hero";
 import SubHero from "@/components/Hero/SubHero";
 import Search from "@/components/Search";
 import { PublisherCard, TopicCard } from "@/components/CardList/CardTypes";
@@ -120,7 +129,28 @@ const CardListPublisherItems = [
 export default async function Home() {
   return (
     <>
-      <Hero
+      <Hero>
+        <HeroPhaseBanner href="#" tag={{ children: "alpha" }} />
+        <HeroMainContent>
+          <HeroMainContentTitle title="Find government statistics and data" />
+          <HeroMainContentDescription description="Browse statistical summaries and download associated data to help you understand and analyse our range of statistics." />
+        </HeroMainContent>
+        <HeroActionButton href="/catalogue" text="View data catalogue" />
+      </Hero>
+      <div style={{ paddingBottom: 200 }}></div>
+      <Hero className="alternative">
+        <HeroPhaseBanner
+          href="#"
+          tag={{ children: "alpha", className: "alternative" }}
+        />
+        <HeroBreadcrumbs />
+        <HeroMainContent>
+          <HeroMainContentCaption caption="Topic" />
+          <HeroMainContentTitle title="Agriculture, energy and environment" />
+          <HeroMainContentDescription description="Food and farming, the natural environment, animal and plant health, flooding and water, fisheries, and environmental quality." />
+        </HeroMainContent>
+      </Hero>
+      {/* <Hero
         title="Find government statistics and data"
         description="Browse statistical summaries and download associated data to help you understand and analyse our range of statistics."
         startButton={{ href: "/catalogue", text: "View data catalogue" }}
@@ -128,7 +158,17 @@ export default async function Home() {
           href: "#",
           tag: { children: "alpha" },
         }}
-      />
+      /> */}
+      {/* <Hero
+        title="Agriculture, energy and environment"
+        caption="Topic"
+        description="Food and farming, the natural environment, animal and plant health, flooding and water, fisheries, and environmental quality."
+        className="alternative"
+        phaseBanner={{
+          href: "#",
+          tag: { children: "alpha", className: "alternative" },
+        }}
+      /> */}
       <SubHero>
         <Search />
       </SubHero>

--- a/components/Hero/_hero.scss
+++ b/components/Hero/_hero.scss
@@ -6,6 +6,11 @@
   background-color: govuk-colour("blue");
 }
 
+.app-hero.alternative {
+  border-bottom: 1px solid govuk-colour("dark-grey");
+  background-color: govuk-colour("dark-grey");
+}
+
 .app-hero__title {
   color: govuk-colour("white");
   @include govuk-responsive-margin(6, "bottom");
@@ -14,6 +19,10 @@
 .app-hero__description {
   @include govuk-font(24);
   margin-bottom: 0;
+}
+
+.app-hero__caption {
+  color: govuk-colour("white");
 }
 
 .app-hero__image {
@@ -28,4 +37,9 @@
 .app-hero__phase-banner__tag {
   background-color: govuk-colour("white");
   color: govuk-colour("blue");
+}
+
+.app-hero__phase-banner__tag.alternative {
+  background-color: govuk-colour("blue");
+  color: govuk-colour("white");
 }

--- a/components/Hero/_hero.scss
+++ b/components/Hero/_hero.scss
@@ -6,7 +6,7 @@
   background-color: govuk-colour("blue");
 }
 
-.app-hero.alternative {
+.app-hero--alternative {
   border-bottom: 1px solid govuk-colour("dark-grey");
   background-color: govuk-colour("dark-grey");
 }
@@ -39,7 +39,7 @@
   color: govuk-colour("blue");
 }
 
-.app-hero__phase-banner__tag.alternative {
+.app-hero__phase-banner__tag--alternative {
   background-color: govuk-colour("blue");
   color: govuk-colour("white");
 }

--- a/components/Hero/index.tsx
+++ b/components/Hero/index.tsx
@@ -41,20 +41,31 @@ function HeroPhaseBanner({
 export default function Hero({
   title,
   description,
+  caption,
   startButton,
   phaseBanner,
+  className,
 }: {
   title: string;
   description: string;
+  caption?: string;
   startButton?: { href: string; text: string };
   phaseBanner?: PhaseBannerProps;
+  className?: string;
 }) {
   return (
-    <div className={"app-hero" + (phaseBanner ? " govuk-!-padding-top-0" : "")}>
+    <div
+      className={
+        `app-hero ${className}` + (phaseBanner ? " govuk-!-padding-top-0" : "")
+      }
+    >
       <div className="app-width-container">
         {phaseBanner ? <HeroPhaseBanner {...phaseBanner} /> : null}
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
+            <span className="govuk-caption-xl app-hero__caption">
+              {caption}
+            </span>
             <h1 className="govuk-heading-xl app-hero__title">{title}</h1>
             <p className="app-hero__description">{description}</p>
           </div>

--- a/components/Hero/index.tsx
+++ b/components/Hero/index.tsx
@@ -26,19 +26,23 @@ const HeroMainContent = ({ children }: { children: any }) => {
   );
 };
 
-const HeroMainContentCaption = ({ caption }: { caption: string }) => (
-  <span className="govuk-caption-xl app-hero__caption">{caption}</span>
+const HeroMainContentCaption = ({ children }: { children: any }) => (
+  <span className="govuk-caption-xl app-hero__caption">{children}</span>
 );
-const HeroMainContentTitle = ({ title }: { title: string }) => (
-  <h1 className="govuk-heading-xl app-hero__title">{title}</h1>
+const HeroMainContentTitle = ({ children }: { children: any }) => (
+  <h1 className="govuk-heading-xl app-hero__title">{children}</h1>
 );
-const HeroMainContentDescription = ({
-  description,
-}: {
-  description: string;
-}) => <p className="app-hero__description">{description}</p>;
+const HeroMainContentDescription = ({ children }: { children: any }) => (
+  <p className="app-hero__description">{children}</p>
+);
 
-const HeroActionButton = ({ href, text }: { href: string; text: string }) => (
+const HeroActionButton = ({
+  children,
+  href,
+}: {
+  children: any;
+  href: string;
+}) => (
   <a
     href={href}
     role="button"
@@ -46,7 +50,7 @@ const HeroActionButton = ({ href, text }: { href: string; text: string }) => (
     className="govuk-button govuk-button--inverse govuk-!-margin-top-6 govuk-!-margin-bottom-0 govuk-button--start"
     data-module="govuk-button"
   >
-    {text}
+    {children}
     <svg
       className="govuk-button__start-icon"
       xmlns="http://www.w3.org/2000/svg"
@@ -62,36 +66,46 @@ const HeroActionButton = ({ href, text }: { href: string; text: string }) => (
 );
 
 function HeroPhaseBanner({
-  href,
-  tag,
+  children,
   className,
-  attributes,
-}: PhaseBannerProps) {
+}: {
+  children: any;
+  className?: string;
+}) {
   return (
     <div
       className={`govuk-phase-banner govuk-phase-banner--inverse govuk-!-margin-bottom-2 ${
         className || ""
       }`}
-      {...attributes}
     >
-      <p className="govuk-phase-banner__content">
-        <Tag
-          className={`govuk-phase-banner__content__tag app-hero__phase-banner__tag ${
-            tag.className || ""
-          }`}
-          {...tag.attributes}
-        >
-          {tag.children}
-        </Tag>
-        <span className="govuk-phase-banner__text govuk-phase-banner__text--inverse">
-          This is a new service - your{" "}
-          <a className="govuk-link govuk-link--inverse" href={href}>
-            feedback
-          </a>{" "}
-          will help us to improve it.
-        </span>
-      </p>
+      <p className="govuk-phase-banner__content">{children}</p>
     </div>
+  );
+}
+
+function HeroPhaseBannerTag({
+  children,
+  className,
+}: {
+  children: any;
+  className?: string;
+}) {
+  return (
+    <Tag
+      className={`govuk-phase-banner__content__tag app-hero__phase-banner__tag ${
+        className || ""
+      }`}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+function HeroPhaseBannerDescription({ children }: { children?: any }) {
+  return (
+    <span className="govuk-phase-banner__text govuk-phase-banner__text--inverse">
+      {children}
+    </span>
   );
 }
 
@@ -111,6 +125,8 @@ export {
   Hero,
   HeroBreadcrumbs,
   HeroPhaseBanner,
+  HeroPhaseBannerTag,
+  HeroPhaseBannerDescription,
   HeroMainContent,
   HeroMainContentCaption,
   HeroMainContentTitle,

--- a/components/Hero/index.tsx
+++ b/components/Hero/index.tsx
@@ -4,6 +4,63 @@ import { PhaseBannerProps } from "@/components/PhaseBanner";
 // The phase banner within the Hero component needs inverse colours to show up
 // against a coloured background.
 
+const HeroBreadcrumbs = () => {
+  return (
+    <div className="govuk-breadcrumbs govuk-breadcrumbs--inverse">
+      <ol className="govuk-breadcrumbs__list">
+        <li className="govuk-breadcrumbs__list-item">
+          <a className="govuk-breadcrumbs__link" href="#">
+            Home
+          </a>
+        </li>
+      </ol>
+    </div>
+  );
+};
+
+const HeroMainContent = ({ children }: { children: any }) => {
+  return (
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-two-thirds">{children}</div>
+    </div>
+  );
+};
+
+const HeroMainContentCaption = ({ caption }: { caption: string }) => (
+  <span className="govuk-caption-xl app-hero__caption">{caption}</span>
+);
+const HeroMainContentTitle = ({ title }: { title: string }) => (
+  <h1 className="govuk-heading-xl app-hero__title">{title}</h1>
+);
+const HeroMainContentDescription = ({
+  description,
+}: {
+  description: string;
+}) => <p className="app-hero__description">{description}</p>;
+
+const HeroActionButton = ({ href, text }: { href: string; text: string }) => (
+  <a
+    href={href}
+    role="button"
+    draggable="false"
+    className="govuk-button govuk-button--inverse govuk-!-margin-top-6 govuk-!-margin-bottom-0 govuk-button--start"
+    data-module="govuk-button"
+  >
+    {text}
+    <svg
+      className="govuk-button__start-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      width="17.5"
+      height="19"
+      viewBox="0 0 33 40"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+    </svg>
+  </a>
+);
+
 function HeroPhaseBanner({
   href,
   tag,
@@ -38,61 +95,25 @@ function HeroPhaseBanner({
   );
 }
 
-export default function Hero({
-  title,
-  description,
-  caption,
-  startButton,
-  phaseBanner,
-  className,
-}: {
-  title: string;
-  description: string;
-  caption?: string;
-  startButton?: { href: string; text: string };
-  phaseBanner?: PhaseBannerProps;
-  className?: string;
-}) {
+function Hero({ children, className }: { children: any; className?: string }) {
   return (
     <div
       className={
-        `app-hero ${className}` + (phaseBanner ? " govuk-!-padding-top-0" : "")
+        `app-hero ${className} govuk-!-padding-top-0` //todo change this for phasebanner conditional
       }
     >
-      <div className="app-width-container">
-        {phaseBanner ? <HeroPhaseBanner {...phaseBanner} /> : null}
-        <div className="govuk-grid-row">
-          <div className="govuk-grid-column-two-thirds">
-            <span className="govuk-caption-xl app-hero__caption">
-              {caption}
-            </span>
-            <h1 className="govuk-heading-xl app-hero__title">{title}</h1>
-            <p className="app-hero__description">{description}</p>
-          </div>
-        </div>
-        {startButton ? (
-          <a
-            href={startButton.href}
-            role="button"
-            draggable="false"
-            className="govuk-button govuk-button--inverse govuk-!-margin-top-6 govuk-!-margin-bottom-0 govuk-button--start"
-            data-module="govuk-button"
-          >
-            {startButton.text}
-            <svg
-              className="govuk-button__start-icon"
-              xmlns="http://www.w3.org/2000/svg"
-              width="17.5"
-              height="19"
-              viewBox="0 0 33 40"
-              aria-hidden="true"
-              focusable="false"
-            >
-              <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
-            </svg>
-          </a>
-        ) : null}
-      </div>
+      <div className="app-width-container">{children}</div>
     </div>
   );
 }
+
+export {
+  Hero,
+  HeroBreadcrumbs,
+  HeroPhaseBanner,
+  HeroMainContent,
+  HeroMainContentCaption,
+  HeroMainContentTitle,
+  HeroMainContentDescription,
+  HeroActionButton,
+};


### PR DESCRIPTION
I ended up reworking the hero header and experimenting with components for each individual part. I think it works quite well in this situation, removing the need for conditional statements and the passing of so many props.
Alternative colour scheme for the hero header for topic page

**components used**
![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/c1dd5c61-6e20-4b04-8998-cb3fde264377)


**normal and alternative colours for hero header** alternative hero header makes use of breadcrumbs, caption, and removes call to action button. 
![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/235e546d-29e5-4d4a-9565-70b278e51106)
