### PR TITLE
Temporal and geographical coverage

### DIFF
--- a/app/datasets/page.tsx
+++ b/app/datasets/page.tsx
@@ -36,7 +36,7 @@ export default async function Datasets({
         <div className="govuk-grid-row">
           <FilterSelection searchParams={params} />
           <DatasetsList
-            items={datasets.items}
+            items={datasets.datasets}
             page={searchParams.page}
             searchParams={searchParams}
             filterParams={params}

--- a/app/datasets/page.tsx
+++ b/app/datasets/page.tsx
@@ -5,14 +5,14 @@ import DatasetsList from "@/components/DatasetsList";
 import PhaseBanner from "@/components/PhaseBanner";
 
 import FilterSelection from "@/components/FilterSelection";
-import { getDatasets } from "../libs/dataRequests";
+import { getDatasetsWithSpatialCoverageInfo } from "../libs/dataRequests";
 
 export default async function Datasets({
   searchParams,
 }: {
   searchParams: any;
 }) {
-  const datasets = await getDatasets();
+  const datasets = await getDatasetsWithSpatialCoverageInfo();
   const KEY = "page";
   const params = new URLSearchParams(searchParams);
   params.delete(KEY);

--- a/app/libs/dataRequests.tsx
+++ b/app/libs/dataRequests.tsx
@@ -51,7 +51,7 @@ const getDatasetsWithSpatialCoverageInfo = async () => {
   const data = await fetchData("/datasets", "GET");
   let codes = new Set<string>();
 
-  data.items.forEach((item: { spatial_coverage: string }) => {
+  data.datasets.forEach((item: { spatial_coverage: string }) => {
     codes.add(item.spatial_coverage);
   });
 
@@ -69,7 +69,7 @@ const getDatasetsWithSpatialCoverageInfo = async () => {
     })
   );
 
-  data.items.forEach(
+  data.datasets.forEach(
     (item: {
       spatial_coverage_name: { code: string; coverage: any };
       spatial_coverage: string;

--- a/components/DatasetsList/_datasetsList.scss
+++ b/components/DatasetsList/_datasetsList.scss
@@ -1,3 +1,5 @@
+@import "../../styles/mixins/chevron";
+
 .app-datasets-list {
   @include govuk-text-colour;
   @include govuk-font(19);
@@ -19,7 +21,7 @@
 .app-datasets-list__item-top {
   padding-left: 0;
   padding-right: 0;
-  margin-bottom: govuk-spacing(7);
+  margin-bottom: govuk-spacing(4);
 }
 
 .app-datasets-list__item-bottom {
@@ -72,9 +74,24 @@
   display: inline-block;
 }
 
+.app-datasets-list__item-topic {
+  @include govuk-text-colour;
+  @include govuk-font(16, "light");
+  color: $govuk-secondary-text-colour;
+  display: flex;
+  flex-direction: row;
+  margin-top: govuk-spacing(1);
+}
+
+.app-datasets-list__chevron {
+  margin-left: govuk-spacing(2) !important;
+  margin-right: govuk-spacing(2) !important;
+  @include chevron-right-small($govuk-secondary-text-colour);
+}
+
 .app-datasets-list__item-description {
   @include govuk-text-colour;
-  margin: govuk-spacing(1) 0 0 0;
+  margin: govuk-spacing(2) 0 0 0;
 }
 
 .app-datasets-list__item-publisher-inner {

--- a/components/DatasetsList/index.tsx
+++ b/components/DatasetsList/index.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import FilterDisplay from "../FilterDisplay";
 import Pagination from "../Pagination";
 
-function DatasetsListItem(props: {
+const DatasetsListItem = (props: {
   title: string;
   summary: string;
   release_date: string;
@@ -15,7 +15,9 @@ function DatasetsListItem(props: {
   publisher: string;
   topic: string;
   subTopic: string;
-}) {
+  spatial_coverage: string;
+  temporal_coverage: { start: string; end: string };
+}) => {
   return (
     <li className="app-datasets-list__item">
       <div className="app-datasets-list__item-top">
@@ -25,6 +27,11 @@ function DatasetsListItem(props: {
         >
           {props?.title}
         </a>
+        <div className="app-datasets-list__item-topic">
+          Topic
+          <div className="app-datasets-list__chevron" />
+          Subtopic
+        </div>
         <p className="app-datasets-list__item-description">{props?.summary}</p>
       </div>
       <div className="app-datasets-list__item-bottom">
@@ -44,20 +51,31 @@ function DatasetsListItem(props: {
           style={{ textAlign: "right" }}
         >
           <li className="app-datasets-list__item-metadata-row">
-            <div>{props?.topic}</div>
-          </li>
-          <li className="app-datasets-list__item-metadata-row">
-            <div>{props?.subTopic}</div>
-          </li>
-          <li className="app-datasets-list__item-metadata-row">
             <time dateTime={props.release_date}>
               Updated: {formatDate(props.release_date)}
             </time>
+          </li>
+          <li className="app-datasets-list__item-metadata-row">
+            <div>
+              Time Period:{" "}
+              {getYear(props?.temporal_coverage.start) +
+                " - " +
+                getYear(props?.temporal_coverage.end)}
+            </div>
+          </li>
+          <li className="app-datasets-list__item-metadata-row">
+            <div>Coverage: {props?.spatial_coverage}</div>
           </li>
         </ul>
       </div>
     </li>
   );
+};
+
+function getYear(dateString: string) {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  return year;
 }
 
 function formatDate(date: string) {

--- a/components/DatasetsList/index.tsx
+++ b/components/DatasetsList/index.tsx
@@ -15,7 +15,7 @@ const DatasetsListItem = (props: {
   publisher: string;
   topic: string;
   subTopic: string;
-  spatial_coverage: string;
+  spatial_coverage_name: string;
   temporal_coverage: { start: string; end: string };
 }) => {
   return (
@@ -64,7 +64,7 @@ const DatasetsListItem = (props: {
             </div>
           </li>
           <li className="app-datasets-list__item-metadata-row">
-            <div>Coverage: {props?.spatial_coverage}</div>
+            <div>Coverage: {props?.spatial_coverage_name}</div>
           </li>
         </ul>
       </div>

--- a/styles/mixins/_chevron.scss
+++ b/styles/mixins/_chevron.scss
@@ -20,3 +20,20 @@
   height: 5px;
   width: 5px;
 }
+
+@mixin chevron-right-small($colour, $update: false) {
+  @if $update == true {
+    border-bottom-color: $colour;
+    border-right-color: $colour;
+  } @else {
+    @include prefixed-transform($rotate: -45deg, $translateY: 130%);
+    border-bottom: 1px solid $colour;
+    border-right: 1px solid $colour;
+    content: "";
+    display: inline-block;
+    height: 5px;
+    width: 5px;
+    margin: 0 10px 0 2px;
+    vertical-align: middle;
+  }
+}

--- a/styles/mixins/_chevron.scss
+++ b/styles/mixins/_chevron.scss
@@ -22,18 +22,8 @@
 }
 
 @mixin chevron-right-small($colour, $update: false) {
-  @if $update == true {
-    border-bottom-color: $colour;
-    border-right-color: $colour;
-  } @else {
-    @include prefixed-transform($rotate: -45deg, $translateY: 130%);
-    border-bottom: 1px solid $colour;
-    border-right: 1px solid $colour;
-    content: "";
-    display: inline-block;
-    height: 5px;
-    width: 5px;
-    margin: 0 10px 0 2px;
-    vertical-align: middle;
-  }
+  @include chevron-small($colour, $update);
+  @include prefixed-transform($rotate: -45deg, $translateY: 130%);
+  border-bottom: 1px solid $colour;
+  border-right: 1px solid $colour;
 }


### PR DESCRIPTION
This ticket is to add the time period and coverage to the dataset item in the datasets list.
Added a new data fetch function to add the geo coverage name from the coverage code, is this something we want to be doing by default or keep it as its own function? Using the findmypostcode api to grab the coverage name.

![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/bdcf786d-450d-476a-a584-79b01c77ee35)
