### PR TITLE
Subtopics arrow

### DIFF
--- a/components/FilterSelection/_filterSelection.scss
+++ b/components/FilterSelection/_filterSelection.scss
@@ -28,16 +28,19 @@
   border-bottom: 1px solid $govuk-border-colour;
 }
 
-.app-accordion[open] {
-  padding-bottom: 0;
-}
-
 .app-accordian__title {
   list-style-type: "";
 }
 
 .app-accordian__title:before {
   @include chevron(govuk-colour("black"));
+}
+
+.app-accordion[open] {
+  padding-bottom: 0;
+  .app-accordian__title:before {
+    @include chevron-up(govuk-colour("black"));
+  }
 }
 
 .app-select {

--- a/components/MultiSelect/_multiSelect.scss
+++ b/components/MultiSelect/_multiSelect.scss
@@ -55,6 +55,10 @@
   @include chevron-small(govuk-colour("black"));
 }
 
+.app-multi-select__option--open:after {
+  @include chevron-up-small(govuk-colour("black"));
+}
+
 .app-multi-select__option--disabled {
   width: 100%;
 }

--- a/components/MultiSelect/index.tsx
+++ b/components/MultiSelect/index.tsx
@@ -93,30 +93,15 @@ const MultiSelect = ({
   };
 
   const SubtopicsDisplay = () => {
-    if (
-      (!isJsEnabled && initialSubtopicsFilter?.length === 0) ||
-      (isJsEnabled && subtopicsFilter?.length === 0)
-    ) {
-      return (
-        <div
-          className={`app-multi-select__option ${
-            isOpen && "app-multi-select__option--open"
-          }`}
-        >
-          All subtopics
-        </div>
-      );
-    }
+    const displayText = !isJsEnabled
+      ? Array.isArray(initialSubtopicsFilter)
+        ? initialSubtopicsFilter.join(", ")
+        : initialSubtopicsFilter
+      : subtopicsFilter?.join(", ");
 
-    let displayText;
-    if (!isJsEnabled) {
-      displayText =
-        typeof initialSubtopicsFilter === "string"
-          ? initialSubtopicsFilter
-          : initialSubtopicsFilter?.join(", ");
-    } else {
-      displayText = subtopicsFilter?.join(", ");
-    }
+    const shouldShowAllSubtopics =
+      (!isJsEnabled && !initialSubtopicsFilter?.length) ||
+      (isJsEnabled && !subtopicsFilter?.length);
 
     return (
       <div
@@ -124,7 +109,7 @@ const MultiSelect = ({
           isOpen && "app-multi-select__option--open"
         }`}
       >
-        {displayText}
+        {shouldShowAllSubtopics ? "All subtopics" : displayText}
       </div>
     );
   };

--- a/components/MultiSelect/index.tsx
+++ b/components/MultiSelect/index.tsx
@@ -97,7 +97,15 @@ const MultiSelect = ({
       (!isJsEnabled && initialSubtopicsFilter?.length === 0) ||
       (isJsEnabled && subtopicsFilter?.length === 0)
     ) {
-      return <div className="app-multi-select__option">All subtopics</div>;
+      return (
+        <div
+          className={`app-multi-select__option ${
+            isOpen && "app-multi-select__option--open"
+          }`}
+        >
+          All subtopics
+        </div>
+      );
     }
 
     let displayText;
@@ -110,7 +118,15 @@ const MultiSelect = ({
       displayText = subtopicsFilter?.join(", ");
     }
 
-    return <div>{displayText}</div>;
+    return (
+      <div
+        className={`app-multi-select__option ${
+          isOpen && "app-multi-select__option--open"
+        }`}
+      >
+        {displayText}
+      </div>
+    );
   };
 
   return (

--- a/styles/mixins/_chevron.scss
+++ b/styles/mixins/_chevron.scss
@@ -21,6 +21,11 @@
   width: 5px;
 }
 
+@mixin chevron-up-small($colour, $update: false) {
+  @include chevron-small($colour, $update);
+  @include prefixed-transform($rotate: -135deg, $translateY: 30%);
+}
+
 @mixin chevron-right-small($colour, $update: false) {
   @include chevron-small($colour, $update);
   @include prefixed-transform($rotate: -45deg, $translateY: 130%);

--- a/styles/mixins/_chevron.scss
+++ b/styles/mixins/_chevron.scss
@@ -15,6 +15,11 @@
   }
 }
 
+@mixin chevron-up($colour, $update: false) {
+  @include chevron($colour, $update);
+  @include prefixed-transform($rotate: -135deg, $translateY: 30%);
+}
+
 @mixin chevron-small($colour, $update: false) {
   @include chevron($colour, $update);
   height: 5px;


### PR DESCRIPTION
This is to address the bug in this [ticket](https://app.zenhub.com/workspaces/cogs-dd-cms-61e83b63053eb70011d37b4f/issues/gh/gss-cogs/dd-cms/961).

Adds a chevron to the multiselect (subtopics) when open and when it has filters selected.
I've also fixed an issue with the filters chevrons not flipping when open.

**to test**
- Go datasets catalogue
- Put a topics and subtopic filter on
- Take note of the chevron on the subtopics
- and
- Open and close the other accordions to see if chevron changes to correct position