### PR TITLE
named routes for notfound/error

### DIFF
--- a/app/error/page.tsx
+++ b/app/error/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Header from "@/components/Header";
+
+export default function Http500() {
+  return (
+    <>
+      <Header borderColour="blue-border" />
+      <div className="app-width-container">
+        <main
+          className="govuk-main-wrapper govuk-main-wrapper--l"
+          id="main-content"
+          role="main"
+        >
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+              <h1 className="govuk-heading-l">
+                Sorry, there is a problem with the service.
+              </h1>
+              <p className="govuk-body">Try again later.</p>
+            </div>
+          </div>
+        </main>
+      </div>
+    </>
+  );
+}

--- a/app/not-found/page.tsx
+++ b/app/not-found/page.tsx
@@ -1,0 +1,36 @@
+import Header from "@/components/Header";
+
+export default function Http404() {
+  return (
+    <>
+      <Header borderColour="blue-border" />
+      <div className="app-width-container">
+        <main
+          className="govuk-main-wrapper govuk-main-wrapper--l"
+          id="main-content"
+          role="main"
+        >
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+              <h1 className="govuk-heading-l">Page not found</h1>
+              <p className="govuk-body">
+                If you typed the web address, check it is correct.
+              </p>
+              <p className="govuk-body">
+                If you pasted the web address, check you copied the entire
+                address.
+              </p>
+              <p className="govuk-body">
+                If the web address is correct or you selected a link or button,{" "}
+                <a href="#" className="govuk-link">
+                  please contact us
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </main>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
This is o address an issue when navigating to the `not-found` and `error` pages. Due to the way we have the `topics` dynamic route set up, any unnamed route would be treated as a topic, throwing an error on that page. If you go to [staging](https://staging.idpd.uk/not-found) you can see the error in question.

**to test**
go to `http://localhost:3000/error` or `http://localhost:3000/not-found` and you shouldn't see any errors