### PR TITLE
check backend url

### DIFF
--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -1,6 +1,8 @@
 // pages/api/health.ts
 import { NextResponse } from "next/server";
 import { headers } from "next/headers";
+// import absoluteUrl from "next-absolute-url";
+import { IncomingMessage } from "http";
 
 const USERNAME = process.env.NEXT_PRIVATE_USERNAME;
 const PASSWORD = process.env.NEXT_PRIVATE_PASSWORD;
@@ -79,12 +81,12 @@ async function getStatusCode(): Promise<number> {
     const headersList = headers();
     const headerUrl = headersList.get("x-url") || "";
     const fullUrl = headerUrl;
-
+    const { origin } = absoluteUrl(headersList);
     const options = {
       method: "GET",
       headers: getHeaders(),
     };
-    const response = await fetch(fullUrl, options);
+    const response = await fetch(origin, options);
     return response.status;
   } catch (error) {
     return 500;
@@ -114,10 +116,9 @@ async function checkDataExplorer(): Promise<HealthCheck> {
     const headersList = headers();
     const header_url = headersList.get("x-url") || "";
 
-    const fullUrl =
-      new URL(header_url).protocol + "//" + new URL(header_url).host;
+    const { origin } = absoluteUrl(headersList);
 
-    check.message = header_url; //"data explorer is unavailable or non-functioning";
+    check.message = origin; //"data explorer is unavailable or non-functioning";
     check.last_failure = new Date();
   }
 
@@ -137,3 +138,30 @@ const getHeaders = () => {
 
   return headers;
 };
+
+function absoluteUrl(req?: any, localhostAddress = "localhost:3000") {
+  let host = req?.get("host") || localhostAddress;
+  let protocol = /^localhost(:\d+)?$/.test(host) ? "http:" : "https:";
+
+  if (
+    req &&
+    req.get("x-forwarded-host") &&
+    typeof req.get("x-forwarded-host") === "string"
+  ) {
+    host = req.get("x-forwarded-host");
+  }
+
+  if (
+    req &&
+    req.get("x-forwarded-proto") &&
+    typeof req.get("x-forwarded-proto") === "string"
+  ) {
+    protocol = `${req.get("x-forwarded-proto")}:`;
+  }
+
+  return {
+    protocol,
+    host,
+    origin: protocol + "//" + host,
+  };
+}

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -111,7 +111,11 @@ async function checkDataExplorer(): Promise<HealthCheck> {
   } else if (statusCode >= 400 && statusCode !== 429) {
     check.status = "CRITICAL";
     check.status_code = 500;
-    check.message = "data explorer is unavailable or non-functioning";
+    const headersList = headers();
+    const domain = headersList.get("x-forwarded-host") || "";
+    const proto = (headersList.get("x-forwarded-proto") || "").split(",")[0];
+    const fullUrl = `${proto}://${domain}`;
+    check.message = fullUrl; //"data explorer is unavailable or non-functioning";
     check.last_failure = new Date();
   }
 
@@ -121,6 +125,7 @@ async function checkDataExplorer(): Promise<HealthCheck> {
 const getHeaders = () => {
   const headers: Record<string, string> = {
     Accept: "text/html",
+    "Content-Type": "text/html",
   };
 
   const basicAuth = `Basic ${Buffer.from(`${USERNAME}:${PASSWORD}`).toString(

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -1,8 +1,6 @@
 // pages/api/health.ts
 import { NextResponse } from "next/server";
 import { headers } from "next/headers";
-// import absoluteUrl from "next-absolute-url";
-import { IncomingMessage } from "http";
 
 const USERNAME = process.env.NEXT_PRIVATE_USERNAME;
 const PASSWORD = process.env.NEXT_PRIVATE_PASSWORD;
@@ -81,12 +79,11 @@ async function getStatusCode(): Promise<number> {
     const headersList = headers();
     const headerUrl = headersList.get("x-url") || "";
     const fullUrl = headerUrl;
-    const { origin } = absoluteUrl(headersList);
     const options = {
       method: "GET",
       headers: getHeaders(),
     };
-    const response = await fetch(origin, options);
+    const response = await fetch(fullUrl, options);
     return response.status;
   } catch (error) {
     return 500;
@@ -113,12 +110,7 @@ async function checkDataExplorer(): Promise<HealthCheck> {
   } else if (statusCode >= 400 && statusCode !== 429) {
     check.status = "CRITICAL";
     check.status_code = 500;
-    const headersList = headers();
-    const header_url = headersList.get("x-url") || "";
-
-    const { origin } = absoluteUrl(headersList);
-
-    check.message = origin; //"data explorer is unavailable or non-functioning";
+    check.message = "data explorer is unavailable or non-functioning";
     check.last_failure = new Date();
   }
 
@@ -138,30 +130,3 @@ const getHeaders = () => {
 
   return headers;
 };
-
-function absoluteUrl(req?: any, localhostAddress = "localhost:3000") {
-  let host = req?.get("host") || localhostAddress;
-  let protocol = /^localhost(:\d+)?$/.test(host) ? "http:" : "https:";
-
-  if (
-    req &&
-    req.get("x-forwarded-host") &&
-    typeof req.get("x-forwarded-host") === "string"
-  ) {
-    host = req.get("x-forwarded-host");
-  }
-
-  if (
-    req &&
-    req.get("x-forwarded-proto") &&
-    typeof req.get("x-forwarded-proto") === "string"
-  ) {
-    protocol = `${req.get("x-forwarded-proto")}:`;
-  }
-
-  return {
-    protocol,
-    host,
-    origin: protocol + "//" + host,
-  };
-}

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -123,10 +123,5 @@ const getHeaders = () => {
     "Content-Type": "text/html",
   };
 
-  // const basicAuth = `Basic ${Buffer.from(`${USERNAME}:${PASSWORD}`).toString(
-  //   "base64"
-  // )}`;
-  // headers.Authorization = basicAuth;
-
   return headers;
 };

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -123,10 +123,10 @@ const getHeaders = () => {
     "Content-Type": "text/html",
   };
 
-  const basicAuth = `Basic ${Buffer.from(`${USERNAME}:${PASSWORD}`).toString(
-    "base64"
-  )}`;
-  headers.Authorization = basicAuth;
+  // const basicAuth = `Basic ${Buffer.from(`${USERNAME}:${PASSWORD}`).toString(
+  //   "base64"
+  // )}`;
+  // headers.Authorization = basicAuth;
 
   return headers;
 };

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -77,9 +77,10 @@ export async function GET() {
 async function getStatusCode(): Promise<number> {
   try {
     const headersList = headers();
-    const domain = headersList.get("x-forwarded-host") || "";
-    const proto = (headersList.get("x-forwarded-proto") || "").split(",")[0];
-    const fullUrl = `asdf${proto}://${domain}`;
+    const headerUrl = headersList.get("x-url") || "";
+    const fullUrl =
+      new URL(headerUrl).protocol + "//" + new URL(headerUrl).host;
+
     const options = {
       method: "GET",
       headers: getHeaders(),
@@ -113,7 +114,10 @@ async function checkDataExplorer(): Promise<HealthCheck> {
     check.status_code = 500;
     const headersList = headers();
     const header_url = headersList.get("x-url") || "";
-    check.message = header_url; //"data explorer is unavailable or non-functioning";
+    const fullUrl =
+      new URL(header_url).protocol + "//" + new URL(header_url).host;
+
+    check.message = fullUrl; //"data explorer is unavailable or non-functioning";
     check.last_failure = new Date();
   }
 

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -112,7 +112,7 @@ async function checkDataExplorer(): Promise<HealthCheck> {
     check.status = "CRITICAL";
     check.status_code = 500;
     const headersList = headers();
-    const domain = headersList.get("x-forwarded-host") || "";
+    const domain = headersList.get("host") || "";
     const proto = (headersList.get("x-forwarded-proto") || "").split(",")[0];
     const fullUrl = `${proto}://${domain}`;
     check.message = fullUrl; //"data explorer is unavailable or non-functioning";

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -112,7 +112,7 @@ async function checkDataExplorer(): Promise<HealthCheck> {
     check.status = "CRITICAL";
     check.status_code = 500;
     const headersList = headers();
-    const domain = headersList.get("host") || "";
+    const domain = headersList.get("referer") || "";
     const proto = (headersList.get("x-forwarded-proto") || "").split(",")[0];
     const fullUrl = `${proto}://${domain}`;
     check.message = fullUrl; //"data explorer is unavailable or non-functioning";

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -79,7 +79,7 @@ async function getStatusCode(): Promise<number> {
     const headersList = headers();
     const domain = headersList.get("x-forwarded-host") || "";
     const proto = (headersList.get("x-forwarded-proto") || "").split(",")[0];
-    const fullUrl = `${proto}://${domain}`;
+    const fullUrl = `asdf${proto}://${domain}`;
     const options = {
       method: "GET",
       headers: getHeaders(),
@@ -112,10 +112,8 @@ async function checkDataExplorer(): Promise<HealthCheck> {
     check.status = "CRITICAL";
     check.status_code = 500;
     const headersList = headers();
-    const domain = headersList.get("referer") || "";
-    const proto = (headersList.get("x-forwarded-proto") || "").split(",")[0];
-    const fullUrl = `${proto}://${domain}`;
-    check.message = fullUrl; //"data explorer is unavailable or non-functioning";
+    const header_url = headersList.get("x-url") || "";
+    check.message = header_url; //"data explorer is unavailable or non-functioning";
     check.last_failure = new Date();
   }
 

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -76,8 +76,8 @@ async function getStatusCode(): Promise<number> {
     const headersList = headers();
     const domain = headersList.get("x-forwarded-host") || "";
     const proto = (headersList.get("x-forwarded-proto") || "").split(",")[0];
-    const fullUrl = `${proto}://${domain}`;
-
+    //const fullUrl = `${proto}://${domain}`;
+    const fullUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "";
     const response = await fetch(fullUrl);
     return response.status;
   } catch (error) {
@@ -105,7 +105,7 @@ async function checkDataExplorer(): Promise<HealthCheck> {
   } else if (statusCode >= 400 && statusCode !== 429) {
     check.status = "CRITICAL";
     check.status_code = 500;
-    check.message = "data explorer is unavailable or non-functioning";
+    check.message = process.env.NEXT_PUBLIC_BACKEND_URL || ""; // "data explorer is unavailable or non-functioning";
     check.last_failure = new Date();
   }
 

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -78,8 +78,7 @@ async function getStatusCode(): Promise<number> {
   try {
     const headersList = headers();
     const headerUrl = headersList.get("x-url") || "";
-    const fullUrl =
-      new URL(headerUrl).protocol + "//" + new URL(headerUrl).host;
+    const fullUrl = headerUrl;
 
     const options = {
       method: "GET",
@@ -114,10 +113,11 @@ async function checkDataExplorer(): Promise<HealthCheck> {
     check.status_code = 500;
     const headersList = headers();
     const header_url = headersList.get("x-url") || "";
+
     const fullUrl =
       new URL(header_url).protocol + "//" + new URL(header_url).host;
 
-    check.message = fullUrl; //"data explorer is unavailable or non-functioning";
+    check.message = header_url; //"data explorer is unavailable or non-functioning";
     check.last_failure = new Date();
   }
 

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -2,9 +2,6 @@
 import { NextResponse } from "next/server";
 import { headers } from "next/headers";
 
-const USERNAME = process.env.NEXT_PRIVATE_USERNAME;
-const PASSWORD = process.env.NEXT_PRIVATE_PASSWORD;
-
 interface HealthCheck {
   name: string;
   status: string;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
+import absoluteUrl from "next-absolute-url";
+import { IncomingMessage } from "http";
 
 export function middleware(request: Request) {
-  // Store current request url in a custom header, which you can read later
+  const { origin } = absoluteUrl(request as unknown as IncomingMessage); // Rename variable to avoid redeclaration
+
   const requestHeaders = new Headers(request.headers);
-  requestHeaders.set("x-url", request.url);
+  requestHeaders.set("x-url", origin);
 
   return NextResponse.next({
     request: {
-      // Apply new request headers
       headers: requestHeaders,
     },
   });

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 export function middleware(request: Request) {
   // Store current request url in a custom header, which you can read later
   const requestHeaders = new Headers(request.headers);
-  requestHeaders.set("x-url", request.headers.get("x-forwarded-host") || "");
+  requestHeaders.set("x-url", request.url);
 
   return NextResponse.next({
     request: {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export function middleware(request: Request) {
+  // Store current request url in a custom header, which you can read later
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-url", request.headers.get("x-forwarded-host") || "");
+
+  return NextResponse.next({
+    request: {
+      // Apply new request headers
+      headers: requestHeaders,
+    },
+  });
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,10 +2,10 @@ import { NextResponse } from "next/server";
 import absoluteUrl from "next-absolute-url";
 import { IncomingMessage } from "http";
 
-export function middleware(request: Request) {
-  const { origin } = absoluteUrl(request as unknown as IncomingMessage); // Rename variable to avoid redeclaration
+export function middleware(request: IncomingMessage) {
+  const { origin } = absoluteUrl(request);
 
-  const requestHeaders = new Headers(request.headers);
+  const requestHeaders = new Headers(request.headers as HeadersInit);
   requestHeaders.set("x-url", origin);
 
   return NextResponse.next({

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,9 @@
         "eslint": "8.44.0",
         "eslint-config-next": "13.4.8",
         "govuk-frontend": "^4.7.0",
+        "moment": "^2.29.4",
         "next": "14.0.3",
+        "next-absolute-url": "^1.2.2",
         "next-logger": "^3.0.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -24,7 +26,8 @@
         "typescript": "5.1.6"
       },
       "devDependencies": {
-        "@types/react-syntax-highlighter": "^15.5.10"
+        "@types/react-syntax-highlighter": "^15.5.10",
+        "pino-pretty": "^10.2.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1177,6 +1180,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
+    },
     "node_modules/comma-separated-tokens": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
@@ -1236,6 +1245,15 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1360,6 +1378,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.15.0",
@@ -1951,6 +1978,12 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+      "dev": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1993,6 +2026,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -2426,6 +2465,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true
     },
     "node_modules/highlight.js": {
       "version": "10.7.3",
@@ -2911,6 +2956,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3128,6 +3182,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3201,6 +3263,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/next-absolute-url": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/next-absolute-url/-/next-absolute-url-1.2.2.tgz",
+      "integrity": "sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg=="
     },
     "node_modules/next-logger": {
       "version": "3.0.2",
@@ -3592,6 +3659,31 @@
         "split2": "^4.0.0"
       }
     },
+    "node_modules/pino-pretty": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
+      "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+      "dev": true,
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
@@ -3680,6 +3772,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -4132,6 +4234,12 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "govuk-frontend": "^4.7.0",
     "moment": "^2.29.4",
     "next": "14.0.3",
+    "next-absolute-url": "^1.2.2",
     "next-logger": "^3.0.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,7 +95,7 @@
 
 "@next/env@14.0.3":
   version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-14.0.3.tgz#9a58b296e7ae04ffebce8a4e5bd0f87f71de86bd"
+  resolved "https://registry.npmjs.org/@next/env/-/env-14.0.3.tgz"
   integrity sha512-7xRqh9nMvP5xrW4/+L0jgRRX+HoNRGnfJpD+5Wq6/13j3dsdzxO3BCXn7D3hMqsDb+vjZnJq+vI7+EtgrYZTeA==
 
 "@next/eslint-plugin-next@13.4.8":
@@ -112,7 +112,7 @@
 
 "@next/swc-darwin-x64@14.0.3":
   version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.3.tgz#48b527ef7eb5dbdcaf62fd107bc3a78371f36f09"
+  resolved "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.3.tgz"
   integrity sha512-RkTf+KbAD0SgYdVn1XzqE/+sIxYGB7NLMZRn9I4Z24afrhUpVJx6L8hsRnIwxz3ERE2NFURNliPjJ2QNfnWicQ==
 
 "@next/swc-linux-arm64-gnu@14.0.3":
@@ -190,7 +190,7 @@
 
 "@swc/helpers@0.5.2":
   version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.2.tgz#85ea0c76450b61ad7d10a37050289eded783c27d"
+  resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz"
   integrity sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==
   dependencies:
     tslib "^2.4.0"
@@ -477,13 +477,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
-  dependencies:
-    balanced-match "^1.0.0"
-
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
@@ -609,7 +602,7 @@ color-name@~1.1.4:
 
 colorette@^2.0.7:
   version "2.0.20"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
 comma-separated-tokens@^1.0.0:
@@ -653,7 +646,7 @@ damerau-levenshtein@^1.0.8:
 
 dateformat@^4.6.3:
   version "4.6.3"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
+  resolved "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
 debug@^3.2.7:
@@ -739,7 +732,7 @@ emoji-regex@^9.2.2:
 
 end-of-stream@^1.1.0:
   version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
@@ -1081,7 +1074,7 @@ execa@^7.1.1:
 
 fast-copy@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.1.tgz#9e89ef498b8c04c1cd76b33b8e14271658a732aa"
+  resolved "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz"
   integrity sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
@@ -1117,7 +1110,7 @@ fast-redact@^3.1.1:
 
 fast-safe-stringify@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  resolved "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
 fastq@^1.6.0:
@@ -1284,17 +1277,6 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
-  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
-
 globals@^13.19.0:
   version "13.20.0"
   resolved "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz"
@@ -1416,13 +1398,10 @@ hastscript@^6.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
-help-me@^4.0.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/help-me/-/help-me-4.2.0.tgz#50712bfd799ff1854ae1d312c36eafcea85b0563"
-  integrity sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==
-  dependencies:
-    glob "^8.0.0"
-    readable-stream "^3.6.0"
+help-me@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz"
+  integrity sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==
 
 highlight.js@^10.4.1, highlight.js@~10.7.0:
   version "10.7.3"
@@ -1475,7 +1454,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1689,7 +1668,7 @@ isexe@^2.0.0:
 
 joycon@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
+  resolved "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
@@ -1830,22 +1809,15 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 moment@^2.29.4:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+  version "2.30.1"
+  resolved "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 ms@2.1.2:
   version "2.1.2"
@@ -1859,13 +1831,18 @@ ms@^2.1.1:
 
 nanoid@^3.3.6:
   version "3.3.7"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+next-absolute-url@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/next-absolute-url/-/next-absolute-url-1.2.2.tgz"
+  integrity sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg==
 
 next-logger@^3.0.2:
   version "3.0.2"
@@ -1877,7 +1854,7 @@ next-logger@^3.0.2:
 
 next@14.0.3:
   version "14.0.3"
-  resolved "https://registry.yarnpkg.com/next/-/next-14.0.3.tgz#8d801a08eaefe5974203d71092fccc463103a03f"
+  resolved "https://registry.npmjs.org/next/-/next-14.0.3.tgz"
   integrity sha512-AbYdRNfImBr3XGtvnwOxq8ekVCwbFTv/UJoLwmaX89nk9i051AEY4/HAWzU0YpaTDw8IofUpmuIlvzWF13jxIw==
   dependencies:
     "@next/env" "14.0.3"
@@ -2108,15 +2085,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pino-abstract-transport@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz#083d98f966262164504afb989bccd05f665937a8"
-  integrity sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==
-  dependencies:
-    readable-stream "^4.0.0"
-    split2 "^4.0.0"
-
-pino-abstract-transport@v1.0.0:
+pino-abstract-transport@^1.0.0, pino-abstract-transport@v1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz"
   integrity sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==
@@ -2125,15 +2094,15 @@ pino-abstract-transport@v1.0.0:
     split2 "^4.0.0"
 
 pino-pretty@^10.2.3:
-  version "10.2.3"
-  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-10.2.3.tgz#db539c796a1421fd4d130734fa994f5a26027783"
-  integrity sha512-4jfIUc8TC1GPUfDyMSlW1STeORqkoxec71yhxIpLDQapUu8WOuoz2TTCoidrIssyz78LZC69whBMPIKCMbi3cw==
+  version "10.3.1"
+  resolved "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz"
+  integrity sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==
   dependencies:
     colorette "^2.0.7"
     dateformat "^4.6.3"
     fast-copy "^3.0.0"
     fast-safe-stringify "^2.1.1"
-    help-me "^4.0.1"
+    help-me "^5.0.0"
     joycon "^3.1.1"
     minimist "^1.2.6"
     on-exit-leak-free "^2.1.0"
@@ -2168,7 +2137,7 @@ pino@^8.11.0:
 
 postcss@8.4.31:
   version "8.4.31"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz"
   integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
   dependencies:
     nanoid "^3.3.6"
@@ -2218,7 +2187,7 @@ property-information@^5.0.0:
 
 pump@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  resolved "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz"
   integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
   dependencies:
     end-of-stream "^1.1.0"
@@ -2274,15 +2243,6 @@ react@18.2.0:
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-
-readable-stream@^3.6.0:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
-  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
 
 readable-stream@^4.0.0:
   version "4.4.2"
@@ -2426,7 +2386,7 @@ scheduler@^0.23.0:
 
 secure-json-parse@^2.4.0:
   version "2.7.0"
-  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
+  resolved "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz"
   integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
 
 semver@^6.3.0:
@@ -2477,14 +2437,7 @@ slash@^4.0.0:
   resolved "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
-sonic-boom@^3.0.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-3.7.0.tgz#b4b7b8049a912986f4a92c51d4660b721b11f2f2"
-  integrity sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==
-  dependencies:
-    atomic-sleep "^1.0.0"
-
-sonic-boom@^3.1.0:
+sonic-boom@^3.0.0, sonic-boom@^3.1.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz"
   integrity sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==
@@ -2552,7 +2505,7 @@ string.prototype.trimstart@^1.0.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-string_decoder@^1.1.1, string_decoder@^1.3.0:
+string_decoder@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
@@ -2723,11 +2676,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 watchpack@2.4.0:
   version "2.4.0"


### PR DESCRIPTION
This is to sort an issue we was having with the `/health` endpoint. It was showing a critical status even if the site was operational.
It would work locally but not when deployed. The issue was around getting the sites url, nextjs can get the url client side but doesn't have any clear routes to get it from an api route. So was originally using the `headers()` function and getting the host and protocol from that but when deployed it would return the url as `frontend_homepage`.
I found a work around by creating some middleware that would add a custom header `x-url` that contained the url we needed. This is gotten with this tiny [library](https://www.npmjs.com/package/next-absolute-url).
I wanted to avoid using the env var BACKEND_URL in the off chance in the future the site url and this differ from each other.

**to test**
boot up, head over to `http://localhost:3000/health` check thats working.
deploy this branch to staging and go to `https://staging.idpd.uk/health` check if thats working too.