### PR TITLE
topic names

### DIFF
--- a/components/DatasetsList/index.tsx
+++ b/components/DatasetsList/index.tsx
@@ -19,6 +19,7 @@ const DatasetsListItem = (props: {
   subTopic: string;
   spatial_coverage_name: string;
   temporal_coverage: { start: string; end: string };
+  topics_full: { title: string }[];
 }) => {
   const PublisherComponent =
     logoCompDict[props.publisher] || logoCompDict["default"];
@@ -33,9 +34,14 @@ const DatasetsListItem = (props: {
           {props?.title}
         </a>
         <div className="app-datasets-list__item-topic">
-          Topic
-          <div className="app-datasets-list__chevron" />
-          Subtopic
+          {props?.topics_full.map((topic, index) => (
+            <>
+              <span key={topic.title}>{topic.title}</span>
+              {index + 1 < props?.topics_full.length && (
+                <div className="app-datasets-list__chevron" />
+              )}
+            </>
+          ))}
         </div>
         <p className="app-datasets-list__item-description">{props?.summary}</p>
       </div>

--- a/libs/dataRequests.tsx
+++ b/libs/dataRequests.tsx
@@ -94,6 +94,7 @@ const getDatasetsWithSpatialCoverageInfo = async () => {
 
   try {
     logInfo(`fetching data from ${geoportalUrl}`, "GET", geoportalUrl);
+    // add spatial coverage name to each dataset
     const geoportalCodes = await handleResponse(await fetch(geoportalUrl));
 
     const codesMap = new Map<string, string>(
@@ -111,6 +112,7 @@ const getDatasetsWithSpatialCoverageInfo = async () => {
       }
     );
 
+    // add full publisher information to each dataset
     const response = await getPublishers();
     let publishersDict: any = {};
 
@@ -126,6 +128,29 @@ const getDatasetsWithSpatialCoverageInfo = async () => {
         publisher: string;
       }) => {
         item.publisher_full = publishersDict[item.publisher];
+      }
+    );
+
+    // add full topic information to each dataset
+    const topics = await getTopics();
+    let topicsDict: any = {};
+
+    for (const topic of topics.topics) {
+      if (topic.hasOwnProperty("@id")) {
+        topicsDict[topic["@id"]] = topic;
+      }
+    }
+
+    data.datasets.forEach(
+      (item: {
+        topics_full: { code: string; coverage: any }[];
+        topics: string[];
+      }) => {
+        item.topics_full = [];
+
+        item.topics.forEach((topic: string) => {
+          item.topics_full.push(topicsDict[topic]);
+        });
       }
     );
 


### PR DESCRIPTION
This removes the 'Topic > Subtopic' from the dataset items on the data catalogue page, and replaces it with the topics.

![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/1bdec9ac-d34f-419d-888e-c1a9907076f7)

**to test**
Go to the data catalogue page and see if each dataset now has a topic name under each title.