### PR TITLE
dfe crown logo

### DIFF
--- a/utils/logoCompDict.tsx
+++ b/utils/logoCompDict.tsx
@@ -45,7 +45,11 @@ const createLogoComponent =
 const defaulLogoComponent =
   () =>
   ({ title }: LogoProps) =>
-    <div className="app-datasets-list__item-bottom-publisher">{title}</div>;
+    (
+      <div className="app-datasets-list__item-bottom-publisher">
+        <h3 className="app-datasets-list__item-publisher-inner">{title}</h3>
+      </div>
+    );
 
 const logoCompDict: LogoCompDict = {
   "https://staging.idpd.uk/publishers/office-for-national-statistics":
@@ -53,6 +57,8 @@ const logoCompDict: LogoCompDict = {
       "/assets/images/ONS_Logo_Digital_Colour_English_RGB.svg"
     ),
   "https://staging.idpd.uk/publishers/department-for-energy-security-and-net-zero":
+    createLogoComponent("/assets/images/crest.png"),
+  "https://staging.idpd.uk/publishers/department-for-education":
     createLogoComponent("/assets/images/crest.png"),
   default: defaulLogoComponent(),
 };


### PR DESCRIPTION
This is a quick fix for adding the dfe to our logo dictionary.

**previous**
![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/dfd9da14-6afc-434b-a84a-7285bd0f74e6)

**fix**
![image](https://github.com/GSS-Cogs/idpd-frontend-homepage/assets/110108574/79fb573c-4b27-407e-8fa8-b24f84ad3a4d)

**to test**
Head over to the data catalogue and there should be one dataset from the department for education.

Longer term it might be worth just defaulting to use the crown logo so only need to name the ones that have a different logo, ons, ofcom, etc.